### PR TITLE
ask for personal fork in rerender failure notice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
       echo "installing miniconda"
       rm -rf $HOME/miniconda
       mkdir -p $HOME/download
-      curl -s https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o $HOME/download/miniconda.sh
+      curl -sL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o $HOME/download/miniconda.sh
       bash $HOME/download/miniconda.sh -b -p $HOME/miniconda
 
       export PATH=$HOME/miniconda/bin:$PATH

--- a/webservices_dispatch_action/rerendering.py
+++ b/webservices_dispatch_action/rerendering.py
@@ -41,6 +41,7 @@ def comment_and_push_per_changed(
 Hi! This is the friendly automated conda-forge-webservice.
 I tried to rerender for you, but it looks like I wasn't able to push to the {}
 branch of {}/{}. Did you check the "Allow edits from maintainers" box?
+Is the PR's source a personal fork?
 """.format(pr_branch, pr_owner, pr_repo)
     else:
         if rerender_error:

--- a/webservices_dispatch_action/rerendering.py
+++ b/webservices_dispatch_action/rerendering.py
@@ -41,7 +41,9 @@ def comment_and_push_per_changed(
 Hi! This is the friendly automated conda-forge-webservice.
 I tried to rerender for you, but it looks like I wasn't able to push to the {}
 branch of {}/{}. Did you check the "Allow edits from maintainers" box?
-Is the PR's source a personal fork?
+
+**NOTE**: PRs from organization accounts cannot be rerendered because of GitHub 
+permissions.
 """.format(pr_branch, pr_owner, pr_repo)
     else:
         if rerender_error:


### PR DESCRIPTION
Currently only personal forks allow the "allow maintainer changes"
functionality in a PR.
refs https://github.com/conda-forge/webservices-dispatch-action/issues/4

