### PR TITLE
Enable CI restart & rebuild for new `git`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ on:
   pull_request: null
   schedule:
      - cron: "0 6 * * SUN"  # Once weekly on Sunday @ 0600 UTC
+  workflow_dispatch: null
 
 jobs:
   tests:

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,6 @@ RUN echo "**** install dev packages ****" && \
     mamba install --quiet \
         git \
         python="3.10" \
-        "setuptools<66.0.0a" \
         "conda-smithy>=3.22.0" \
         conda-forge-pinning \
         conda-build \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN echo "**** install dev packages ****" && \
     mamba install --quiet \
         git \
         python="3.10" \
-        "setuptools<66.0.0" \
+        "setuptools<66.0.0a" \
         "conda-smithy>=3.22.0" \
         conda-forge-pinning \
         conda-build \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN echo "**** install dev packages ****" && \
     mamba install --quiet \
         git \
         python="3.10" \
+        "setuptools<66.0.0" \
         "conda-smithy>=3.22.0" \
         conda-forge-pinning \
         conda-build \

--- a/entrypoint
+++ b/entrypoint
@@ -17,9 +17,12 @@ conda config --set channel_priority strict
 
 conda activate base
 
-mamba update conda-smithy conda-forge-pinning conda-build -y
+mamba update --all
+# mamba update conda-smithy conda-forge-pinning conda-build -y
 
 conda info
+
+conda list
 
 echo " "
 echo "==================================================================================================="


### PR DESCRIPTION
~Currently `setuptools` version `66.0.0` breaks re-rendering. This will inevitably affect the bot. So pin to an older `setuptools` to protect against it.~

Also `git` [fixed some CVEs recently]( https://github.blog/2023-01-17-git-security-vulnerabilities-announced-2/ ) in `2.39.1` ( https://github.com/conda-forge/git-feedstock/pull/127 ). The new package is in conda-forge, but we need a rebuild of the image to get it.

Finally add a button on CI to enable kicking off a build of the image manually when needed.

xref: https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/3973