### PR TITLE
Remove defaults channel

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -13,9 +13,10 @@ conda activate base
 conda config --set show_channel_urls True
 conda config --add channels conda-forge
 conda config --remove channels defaults || true
-conda config --show-sources
-conda config --set always_yes yes
 conda config --set channel_priority strict
+conda config --set always_yes yes
+
+conda config --show-sources
 
 conda update --all --yes
 

--- a/entrypoint
+++ b/entrypoint
@@ -12,6 +12,7 @@ git config --global user.email "91080706+conda-forge-webservices[bot]@users.nore
 conda activate base
 conda config --set show_channel_urls True
 conda config --add channels conda-forge
+conda config --remove channels defaults || true
 conda config --show-sources
 conda config --set always_yes yes
 conda config --set channel_priority strict


### PR DESCRIPTION
gh-56 added the `channel_priority: strict` config entry -- which is fine to have here, of course.
The actual fix would be to remove the `defaults` channel from the config overall, which this PR does.
(supersedes gh-57)