### PR TITLE
fix: add git pull in tests before push

### DIFF
--- a/tests/run_live_rerender_test.py
+++ b/tests/run_live_rerender_test.py
@@ -154,6 +154,7 @@ jobs:
     )
 
     print("push to origin...", flush=True)
+    subprocess.run("git pull", shell=True, check=True)
     subprocess.run("git push", shell=True, check=True)
 
 


### PR DESCRIPTION
This PR adds a pull before the push to try and get the tests to run properly.

closes #75 