### PR TITLE
fix: push docker image right away and do not rerun tests

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,6 +1,7 @@
 name: container
 
 on:
+  workflow_dispatch: null
   push:
     branches:
       - main

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,43 @@
+name: container
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  container:
+    name: push container
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+
+      - name: set up docker buildx
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3
+
+      - name: login to docker hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
+        with:
+          username: condaforgebot
+          password: ${{ secrets.CF_BOT_DH_PASSWORD }}
+
+      - name: build and push
+        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 # v5
+        with:
+          push: true
+          tags: condaforge/webservices-dispatch-action:prod
+
+      - name: push README to docker hub
+        uses: christian-korneck/update-container-description-action@d36005551adeaba9698d8d67a296bd16fa91f8e8 # v1
+        env:
+          DOCKER_USER: condaforgebot
+          DOCKER_PASS: ${{ secrets.CF_BOT_DH_PASSWORD }}
+        with:
+          destination_container_repo: condaforge/webservices-dispatch-action:prod
+          provider: dockerhub
+          short_description: "conda-forge image used to power the admin webservices GitHub Actions integrations"
+          readme_file: "Dockerfile_README.md"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,6 @@
 name: tests
 
 on:
-  push:
-    branches:
-      - main
   pull_request: null
   merge_group: null
 
@@ -103,38 +100,3 @@ jobs:
           python tests/run_live_version_update_test.py --version=0.14 --branch=${{ steps.live_tests.outputs.branch }}
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
-
-  docker-push:
-    name: push docker image
-    runs-on: "ubuntu-latest"
-    needs: tests
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: checkout code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-
-      - name: set up docker buildx
-        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3
-
-      - name: login to docker hub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
-        with:
-          username: condaforgebot
-          password: ${{ secrets.CF_BOT_DH_PASSWORD }}
-
-      - name: build and push
-        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 # v5
-        with:
-          push: true
-          tags: condaforge/webservices-dispatch-action:prod
-
-      - name: push README to docker hub
-        uses: christian-korneck/update-container-description-action@d36005551adeaba9698d8d67a296bd16fa91f8e8 # v1
-        env:
-          DOCKER_USER: condaforgebot
-          DOCKER_PASS: ${{ secrets.CF_BOT_DH_PASSWORD }}
-        with:
-          destination_container_repo: condaforge/webservices-dispatch-action:prod
-          provider: dockerhub
-          short_description: "conda-forge image used to power the admin webservices GitHub Actions integrations"
-          readme_file: "Dockerfile_README.md"


### PR DESCRIPTION
This PR ensures that we minimize race conditions between when a new docker image is pushed and the action code is updated.